### PR TITLE
Build binaries for IBM Z (s390x) architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,17 @@ language: node_js
 node_js:
   - "lts/*"
 
+arch:
+  - amd64
+  - s390x
+
 services:
   - docker
 
 script:
   # Audit npm packages. Fail build whan a PR audit fails, otherwise report the vulnerability and proceed.
   - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then npm audit; else npm audit || true; fi
-  - npm run lint
+  - if [[ "$TRAVIS_CPU_ARCH" == "s390x" ]]; then npm run lint-s390x; else npm run lint; fi
   - npm test
   - docker build --rm -t "quay.io/razee/watch-keeper:${TRAVIS_COMMIT}" .
   - if [ -n "${TRAVIS_TAG}" ]; then docker tag quay.io/razee/watch-keeper:${TRAVIS_COMMIT} quay.io/razee/watch-keeper:${TRAVIS_TAG}; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -161,4 +161,4 @@ jobs:
          on:
            tags: true
            condition: ${TRAVIS_TAG} =~ ^[0-9]+\.[0-9]+\.[0-9]+$
-     
+

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "test:debug": "KUBECONFIG=./testdata/kubeconfig.yaml mocha --inspect-brk",
     "check-coverage": "KUBECONFIG=./testdata/kubeconfig.yaml nyc check-coverage --statements 35 --branches 20 --functions 25 --lines 35",
     "lint": "run-s eslint dockerlint yamllint jsonlint shlint markdownlint",
-    "lint-s390x": "run-s eslint dockerlint yamllint jsonlint markdownlint",
     "eslint": "npx eslint src/ test/",
     "dockerlint": "npx dockerlint Dockerfile",
     "jsonlint": "npx jsonlint --quiet .eslintrc.json && npx jsonlint --quiet build/viewTemplate.json && npx jsonlint --quiet package.json && npx jsonlint --quiet package-lock.json",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:debug": "KUBECONFIG=./testdata/kubeconfig.yaml mocha --inspect-brk",
     "check-coverage": "KUBECONFIG=./testdata/kubeconfig.yaml nyc check-coverage --statements 35 --branches 20 --functions 25 --lines 35",
     "lint": "run-s eslint dockerlint yamllint jsonlint shlint markdownlint",
+    "lint-s390x": "run-s eslint dockerlint yamllint jsonlint markdownlint",
     "eslint": "npx eslint src/ test/",
     "dockerlint": "npx dockerlint Dockerfile",
     "jsonlint": "npx jsonlint --quiet .eslintrc.json && npx jsonlint --quiet build/viewTemplate.json && npx jsonlint --quiet package.json && npx jsonlint --quiet package-lock.json",


### PR DESCRIPTION
Updated .travis.yml file to build container images for IBM Z (s390x) in Travis CI. Also executing unit tests on s390x. Travis CI jobs for both amd64 and s390x passed on the fork. 
![image](https://user-images.githubusercontent.com/21959540/103375208-6da0d380-4a8e-11eb-9873-964876f1dd85.png)
