### PR TITLE
fix: allow self-signed ingress certificates to be trusted

### DIFF
--- a/kubernetes/watch-keeper/resource.yaml
+++ b/kubernetes/watch-keeper/resource.yaml
@@ -34,6 +34,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: NODE_EXTRA_CA_CERTS
+              value: /home/node/envs/watch-keeper-secret/cacerts.pem
             - name: USER_AGENT_NAME
               value: razee-io/watchkeeper
             - name: USER_AGENT_VERSION


### PR DESCRIPTION
By adding the NODE_EXTRA_CA_CERTS environment variable we can let razeedash trust self-signed certs which is needed if the ingress for your razeedash-api is self-signed. Otherwise you get the following in WatchKeeper:

```
{"name":"DelayedSendArray","hostname":"watch-keeper-6fd5996f7f-z4nvr","pid":1,"level":50,"err":{"message":"self signed certificate in certificate chain","name":"Error","stack":"Error: self signed certificate in certificate chain\n    at TLSSocket.onConnectSecure (_tls_wrap.js:1497:34)\n    at TLSSocket.emit (events.js:315:20)\n    at TLSSocket._finishInit (_tls_wrap.js:932:8)\n    at TLSWrap.ssl.onhandshakedone (_tls_wrap.js:706:12)","code":"SELF_SIGNED_CERT_IN_CHAIN"},"msg":"self signed certificate in certificate chain","time":"2021-04-22T17:31:22.889Z","v":0}
```

To enable this you just add your certificate to the watch-keeper-secret secret with the key cacerts.pem. If you don't have that key in your secrets WatchKeeper still starts up fine, just no additional certs being accepted