### PR TITLE
Read razee-identity secret via kube api

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -23,6 +23,7 @@
         "notes": "The Request package (see above) requires tough-cookie at a vulnerable version.",
         "expiry": "2024-02-30"
       }
-    }    ],
+    }
+  ],
   "skip-dev": true
 }

--- a/kubernetes/watch-keeper/resource.yaml
+++ b/kubernetes/watch-keeper/resource.yaml
@@ -72,8 +72,6 @@ spec:
               mountPath: /home/node/envs/watch-keeper-secret
             - name: razee-identity-config
               mountPath: /home/node/envs/razee-identity-config
-            - name: razee-identity-secret
-              mountPath: /home/node/envs/razee-identity-secret
       volumes:
         - name: watch-keeper-config
           configMap:
@@ -88,10 +86,5 @@ spec:
         - name: razee-identity-config
           configMap:
             name: razee-identity
-            defaultMode: 0400
-            optional: true
-        - name: razee-identity-secret
-          secret:
-            secretName: razee-identity
             defaultMode: 0400
             optional: true

--- a/src/Config.js
+++ b/src/Config.js
@@ -20,8 +20,7 @@ const chokidar = require('chokidar');
 module.exports = class Config {
   static razeedashUrlPath1 = 'envs/watch-keeper-config/RAZEEDASH_URL';
   static razeedashUrlPath2 = 'envs/razee-identity-config/RAZEE_API';
-  static orgKeyPath1 = 'envs/razee-identity-secret/RAZEE_ORG_KEY';
-  static orgKeyPath2 = 'envs/watch-keeper-secret/RAZEEDASH_ORG_KEY';
+  static orgKeyPath = 'envs/watch-keeper-secret/RAZEEDASH_ORG_KEY';
   static clusterIdPath1 = 'envs/razee-identity-config/CLUSTER_ID';
   static clusterIdPath2 = 'envs/watch-keeper-config/CLUSTER_ID_OVERRIDE';
   static clusterNamePath1 = 'envs/razee-identity-config/CLUSTER_NAME';
@@ -57,9 +56,7 @@ module.exports = class Config {
   }
 
   static async readOrgKey() {
-    if (await fs.pathExists(this.orgKeyPath1)) {
-      this.orgKey = ((await fs.readFile(this.orgKeyPath1, 'utf8')).trim() || this.orgKey);
-    } else if (await fs.pathExists(this.orgKeyPath2)) {
+    if (await fs.pathExists(this.orgKeyPath)) {
       this.orgKey = ((await fs.readFile(this.orgKeyPath2, 'utf8')).trim() || this.orgKey);
     }
   }
@@ -136,7 +133,7 @@ module.exports = class Config {
           this.readRazeedashUrl();
         }
 
-        if (path === this.orgKeyPath1 || path === this.orgKeyPath2) {
+        if (path === this.orgKeyPath) {
           this.readOrgKey();
         }
 

--- a/src/razeedash/Heartbeat.js
+++ b/src/razeedash/Heartbeat.js
@@ -19,6 +19,7 @@ const HttpAgent = require('agentkeepalive');
 const HttpsAgent = require('agentkeepalive').HttpsAgent;
 const log = require('../bunyan-api').createLogger('Heartbeat');
 const Config = require('../Config');
+const Util = require('./Util');
 
 const httpsAgent = new HttpsAgent({
   keepAlive: true
@@ -47,12 +48,21 @@ module.exports = class Heartbeat {
 
   async heartbeat(customMeta) {
     log.info('Sending Heartbeat ============');
+
+    let orgKey;
+    try {
+      orgKey = await Util.getOrgKey();
+    }
+    catch(e) {
+      orgKey = Config.orgKey;
+    }
+
     return RequestLib.doRequest({
       url: `${this.url}/clusters/${this._clusterID}`,
       method: 'POST',
       agent: this.agent,
       headers: {
-        'razee-org-key': Config.orgKey
+        'razee-org-key': orgKey
       },
       json: true,
       body: customMeta,

--- a/src/razeedash/Messenger.js
+++ b/src/razeedash/Messenger.js
@@ -18,6 +18,7 @@ const HttpAgent = require('agentkeepalive');
 const HttpsAgent = require('agentkeepalive').HttpsAgent;
 const validUrl = require('valid-url');
 const Config = require('../Config');
+const Util = require('./Util');
 
 const httpsAgent = new HttpsAgent({
   keepAlive: true
@@ -63,12 +64,21 @@ module.exports = class Messenger {
       data: data
     };
     let url = this._clusterID ? `${this.url}/clusters/${this._clusterID}/messages` : `${this.url}/messages`;
+
+    let orgKey;
+    try {
+      orgKey = await Util.getOrgKey();
+    }
+    catch(e) {
+      orgKey = Config.orgKey;
+    }
+
     return RequestLib.doRequestRetry({
       url: url,
       method: 'POST',
       agent: this.agent,
       headers: {
-        'razee-org-key': Config.orgKey
+        'razee-org-key': orgKey
       },
       json: true,
       body: body,

--- a/src/razeedash/Util.js
+++ b/src/razeedash/Util.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const log = require('../bunyan-api').createLogger('Util');
 const objectPath = require('object-path');
 const { KubeClass } = require('@razee/kubernetes-util');
 const kc = new KubeClass();
@@ -29,5 +28,5 @@ module.exports = class Util {
     }
     let secret = Buffer.from(base64KeyData, 'base64');
     return secret.toString();
-  };
+  }
 };

--- a/src/razeedash/Util.js
+++ b/src/razeedash/Util.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2024 IBM Corp. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const log = require('../bunyan-api').createLogger('Util');
+const objectPath = require('object-path');
+const { KubeClass } = require('@razee/kubernetes-util');
+const kc = new KubeClass();
+
+module.exports = class Util {
+  // Read from razee-identity secret dynamically (rather than mounting as a volume and reading from a file) to satisfy scenarios where this operator is run on a separate cluster
+  static async getOrgKey() {
+    const krm = await kc.getKubeResourceMeta('v1', 'Secret', 'get');
+    const res = await krm.request({ uri: '/api/v1/namespaces/razeedeploy/secrets/razee-identity', json: true });
+    let base64KeyData = objectPath.get(res, ['data', 'RAZEE_ORG_KEY']);
+    if (base64KeyData === undefined) {
+      throw new Error('razeedeploy/razee-identity secret does not contain RAZEE_ORG_KEY');
+    }
+    let secret = Buffer.from(base64KeyData, 'base64');
+    return secret.toString();
+  };
+};


### PR DESCRIPTION
Read razee-identity secret via kube api to enable scenarios where the operator is run from a separate kube cluster but with config allowing it to call the kube api of the managed cluster.